### PR TITLE
[UPDATES] Remove email updation from account settings page

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,10 +10,6 @@
       </div>
 
       <div class="mb-3">
-        <%= f.email_field :email, class: 'form-control', placeholder: 'Email Address', required: true %>
-      </div>
-
-      <div class="mb-3">
         <%= f.label :avatar, class: "form-label" %>
         <div class="flex items-center gap-2">
           <%= image_tag avatar_path(f.object), class: "h-16 w-16 rounded-full my-3" %>


### PR DESCRIPTION
To keep the email same as that of the user github account, removed email field from the account settings edit page.