### PR TITLE
6 lords a-leaping, ffiiiiivvvveee golden votes

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -12,11 +12,7 @@ class Vote < ApplicationRecord
   MAXIMUM = 5
 
   def user_can_have_only_five_votes
-    # Using size here will count the in-memory instances plus the db records
-    # If you have 5 vote records in the database and try to create a 6th record
-    # this validation will fail. However, if you are only updating the order of your
-    # existing votes the validation will pass because there is no in-memory instance.
-    if user.votes.where(event: event).size > MAXIMUM
+    if user.votes.where(event: event).size >= MAXIMUM
       errors.add(:base, "You've reached the #{MAXIMUM} vote limit")
     end
   end


### PR DESCRIPTION
The previous comment implied that the vote count would account for the in-memory vote but it appears the where clause is now blowing that away which was allowing people to vote for 6 entries instead of 5.

This limits the voting to 5 entries per user.