### PR TITLE
Remove the vote button when event voting is done

### DIFF
--- a/app/controllers/events/votes_controller.rb
+++ b/app/controllers/events/votes_controller.rb
@@ -22,6 +22,8 @@ class Events::VotesController < ApplicationController
     vote.destroy
     redirect_back fallback_location: entry_path(vote.entry), notice: "Your vote has been removed successfully."
   end
+  
+  private
 
   def set_event
     @event = Event.find(params[:event_id])

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -67,10 +67,12 @@
       <%= pluralize(@entry.votes.size, "vote") %>
     </div>
 
-    <% if user_signed_in? && current_user.voted_for_entry?(entry: @entry) %>
-      <%= button_to "Remove vote", event_vote_path(@event, current_user.vote_for_entry(@entry)), method: :delete, class: "mt-6 btn btn-white", data: { turbo_confirm: "Are you sure?" } %>
-    <% else %>
-      <%= button_to "Vote for this application", event_votes_path(@event, entry: @entry), class: "mt-6 btn bg-green-500 text-white hover:bg-green-400" %>
+    <% if @entry.event.voting_allowed? %>
+      <% if user_signed_in? && current_user.voted_for_entry?(entry: @entry) %>
+        <%= button_to "Remove vote", event_vote_path(@event, current_user.vote_for_entry(@entry)), method: :delete, class: "mt-6 btn btn-white", data: { turbo_confirm: "Are you sure?" } %>
+      <% else %>
+        <%= button_to "Vote for this application", event_votes_path(@event, entry: @entry), class: "mt-6 btn bg-green-500 text-white hover:bg-green-400" %>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
When an event is finished and the voting is done (currently set at 2 days after the event end time), the button to vote or remove the vote should not be visible. The votes were already disabled and not allowed but the button was still visible on the team entry page.

This removes the button from the page 2 days after the event is done and voting has finished.

<img width="727" alt="image" src="https://github.com/excid3/railshackathon.com/assets/69126959/3087c0e5-d263-4299-a4ed-150fe3092bc8">


<img width="740" alt="image" src="https://github.com/excid3/railshackathon.com/assets/69126959/a07c104d-ab96-4eb4-826c-658fe1ae3e0a">

While checking on this, we noticed that the votes controller did not have the private keyword for methods used as before actions and we aded that as well.
