### PR TITLE
Add Rails Hackathon 2024 Edition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,7 @@
     <%= link_to event, class: "block bg-gray-50 p-8 mb-8 rounded-lg no-underline hover:bg-gray-100" do %>
       <h3 class="mt-0 font-bold"><%= event.theme %></h3>
       <div class="text-sm text-gray-700">
-        <%= local_time(event.start_date, '%b %e, %Y') %> - <%= local_time(event.end_date, '%b %e, %Y') %>
+        <%= local_time(event.start_time, '%b %e, %Y') %> - <%= local_time(event.end_time, '%b %e, %Y') %>
       </div>
     <% end %>
   <% end %>

--- a/db/migrate/20230607153331_create_events.rb
+++ b/db/migrate/20230607153331_create_events.rb
@@ -9,24 +9,6 @@ class CreateEvents < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
-
-    Event.create!(
-      theme: "Hotwire",
-      title: "Hotwire",
-      start_time: DateTime.new(2022, 9, 16, 19, 0, 00),
-      end_time: DateTime.new(2022, 9, 18, 19, 0, 00),
-      published: true,
-      start_time_link: "https://everytimezone.com/s/c64db7ce"
-    )
-
-    Event.create!(
-      theme: "Supporting the Ruby on Rails Community",
-      title: "Supporting Rails",
-      start_time: DateTime.new(2023, 7, 28, 19, 0, 00),
-      end_time: DateTime.new(2023, 7, 30, 19, 0, 00),
-      published: true,
-      start_time_link: "https://everytimezone.com/s/47d3a89a"
-    )
   end
 
   def down

--- a/db/migrate/20230607154259_add_event_id_to_teams.rb
+++ b/db/migrate/20230607154259_add_event_id_to_teams.rb
@@ -1,14 +1,14 @@
 class AddEventIdToTeams < ActiveRecord::Migration[7.0]
   def up
     add_reference :teams, :event, foreign_key: true
-    
+
     event = Event.find_by(theme: "Hotwire")
-    Team.update_all(event_id: event.id)
-    
+    Team.update_all(event_id: event.id) if event
+
     change_column_null :teams, :event_id, false
   end
-  
+
   def down
-     remove_reference :teams, :event, foreign_key: true
-   end
+    remove_reference :teams, :event, foreign_key: true
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,8 +69,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_225101) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "complete"
-    t.integer "votes_count"
     t.integer "total_points", default: 0
+    t.integer "votes_count", default: 0
     t.index ["team_id"], name: "index_entries_on_team_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,33 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+Event.find_or_initialize_by(
+  theme: "Hotwire",
+  title: "Hotwire",
+).update!(
+  start_time: DateTime.parse("2022-09-16 19:00:00 CDT"),
+  end_time: DateTime.parse("2022-09-18 19:00:00 CDT"),
+  published: true,
+  start_time_link: "https://everytimezone.com/s/c64db7ce"
+)
+
+Event.find_or_initialize_by(
+  theme: "Supporting the Ruby on Rails Community",
+  title: "Supporting Rails",
+).update!(
+  start_time: DateTime.parse("2023-07-28 19:00:00 CDT"),
+  end_time: DateTime.parse("2023-07-30 19:00:00 CDT"),
+  published: true,
+  start_time_link: "https://everytimezone.com/s/47d3a89a"
+)
+
+Event.find_or_initialize_by(
+  theme: "Open Hackathon 2024",
+  title: "Open Hackathon 2024"
+).update!(
+  start_time: DateTime.parse("2024-10-25 19:00:00 CDT"),
+  end_time: DateTime.parse("2024-10-27 19:00:00 CDT"),
+  published: true,
+  start_time_link: "https://everytimezone.com/s/2cdcb58f"
+)


### PR DESCRIPTION
This pull requests adds the seeds for a 2024 edition, scheduled for Oct 25 7PM CDT - Oct 27 7PM CDT.

I had to move the event creation in `db/migrate/20230607153331_create_events.rb` to the `db/seeds.rb` file, since it tried to create the events with a `start_time_link`, but this column gets added only in a later migration. Now all the events live in the `db/seeds.rb` file and can be reseeded without creating duplicate events.

Note on timezones: the home page isn't "localized" whereas the events index and event show page is. Is that too confusing? Or should we update the homepage to be localized too using `local_time`? For most people in Europe/Africa/Asia that would mean the dates are in the home page is Oct 26-Oct 28

![CleanShot 2024-08-26 at 16 17 38](https://github.com/user-attachments/assets/209f54b9-a382-4ad8-9a52-cca457093766)

![CleanShot 2024-08-26 at 16 17 45](https://github.com/user-attachments/assets/a0e0a42b-a0f0-4538-b557-d1dc88dbbfac)

![CleanShot 2024-08-26 at 16 17 52](https://github.com/user-attachments/assets/9dbc3630-3911-4746-81eb-4f67b6844c74)
